### PR TITLE
Makefile: do not set SHELL to bash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-SHELL := bash
-
 dist: clean
 	unset stashed; \
 	if [ -n "$$(git status --porcelain --ignored)" ]; then stashed=1; git stash push -qa; fi; \


### PR DESCRIPTION
1. There is no Bash-specific code in the Makefile
2. It's better not to depend on Bash unless necessary.