### PR TITLE
feat: skip over unknown directives

### DIFF
--- a/rstfmt/rstfmt.py
+++ b/rstfmt/rstfmt.py
@@ -264,13 +264,25 @@ class IgnoreMessagesReporter(docutils.utils.Reporter):
         "Title overline too short.",
         "Title underline too short.",
     }
+    ignored_messages_regex = (
+        r'No directive entry for "([\w|\-|:]+)"|'
+        r'Unknown directive type "([\w|\-|:]+)"|'
+        r'No role entry for "([\w|\-|:]+)"|'
+        r'Unknown interpreted text role "([\w|\-|:]+)"'
+    )
 
     def system_message(
         self, level: int, message: str, *children: Any, **kwargs: Any
     ) -> docutils.nodes.system_message:
         orig_level = self.halt_level  # type: ignore
-        if message in self.ignored_messages:
+        res = re.search(self.ignored_messages_regex, message)
+
+        # TODO: Add support for sphinx directives after fix
+        # https://github.com/twolfson/restructuredtext-lint/issues/29
+        if res or message in self.ignored_messages:
             self.halt_level = docutils.utils.Reporter.SEVERE_LEVEL + 1
+        else:
+            print(message)
         msg = super().system_message(level, message, *children, **kwargs)
         self.halt_level = orig_level
         return msg
@@ -724,7 +736,10 @@ def fmt(node: docutils.nodes.Node, ctx: FormatContext) -> Iterator[str]:
     try:
         func = getattr(Formatters, type(node).__name__)
     except AttributeError:
+        if type(node) == docutils.nodes.problematic:
+            return [inline_markup(node.rawsource),]
         raise ValueError(f"Unknown node type {type(node).__name__}!")
+
     return func(node, ctx)  # type: ignore
 
 


### PR DESCRIPTION
Fixes #14, #15

This is my first contribution to anything RST, so it might not be the best approach 😅

Test file:

```
######################
 Prior research
######################

According to :cite:t:`nutt2009`
```

Before this PR:

```
docutils.utils.SystemMessage: :16: (ERROR/3) Unknown interpreted text role "cite:t".
```

After this PR:

- `:cite:p:` kept as-is 🥳

Future enhancement could be to output warnings, maybe?