### PR TITLE
Indirect Hyperlink Support

### DIFF
--- a/rstfmt/rstfmt.py
+++ b/rstfmt/rstfmt.py
@@ -668,9 +668,11 @@ class Formatters:
     def target(node: docutils.nodes.target, ctx: FormatContext) -> line_iterator:
         if not isinstance(node.parent, (docutils.nodes.document, docutils.nodes.section)):
             return
-        try:
+        if "refuri" in node.attributes:
             body = " " + node.attributes["refuri"]
-        except KeyError:
+        elif "refname" in node.attributes:
+            body = " " + node.attributes["refname"] + "_"
+        else:
             body = ""
 
         name = "_" if node.attributes.get("anonymous") else node.attributes["names"][0]

--- a/tests/hyperlinks.rst
+++ b/tests/hyperlinks.rst
@@ -1,0 +1,17 @@
+.. _links:
+
+python_, and `another python`__
+
+.. __: python_
+
+.. _python: https://www.python.org
+
+`and a direct anonymous link`__
+
+.. __: https://docutils.sourceforge.io/rst.html
+
+`example <https://www.example.com>`_
+
+`example but anon <https://www.example.com>`__
+
+links_


### PR DESCRIPTION
This PR adds:

- support for indirect references [based on this example for hyperlinks](https://docutils.sourceforge.io/docs/user/rst/quickref.html#indirect-hyperlink-targets)
- tests for hyperlinks (see same link)
- .vscode to the ignore file because I use vscode :) 

This is implemented very generally -- perhaps too generally, as I cannot find documentation about indirect targets for anything other than links. Maybe this is limited to anonymous links? Maybe assuming the input is at least mostly functional is enough to prevent bad behavior?