### PR TITLE
Add support for `doctest_block`

### DIFF
--- a/rstfmt/rstfmt.py
+++ b/rstfmt/rstfmt.py
@@ -706,6 +706,11 @@ class Formatters:
         yield from with_spaces(3, text.split("\n"))
 
     @staticmethod
+    def doctest_block(node: docutils.nodes.doctest_block, ctx: FormatContext) -> line_iterator:
+        text = "".join(chain(fmt_children(node, ctx)))
+        yield from with_spaces(0, text.split("\n"))
+
+    @staticmethod
     def substitution_definition(
         node: docutils.nodes.substitution_definition, ctx: FormatContext
     ) -> line_iterator:


### PR DESCRIPTION
Doctest blocks are treated as a special case of literal blocks, without requiring the literal block syntax. Indentation is not required for doctest blocks.

https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#doctest-blocks