### PR TITLE
Add error handling for file reading and option to ignore rst formatting errors.

### DIFF
--- a/rstfmt/__main__.py
+++ b/rstfmt/__main__.py
@@ -16,7 +16,7 @@ def do_file(args, fn, misformatted):
     cm = cast(ContextManager[TextIO], nullcontext(sys.stdin) if fn == STDIN else open(fn))
     with cm as f:
         inp = f.read()
-    doc = rstfmt.parse_string(inp)
+    doc = rstfmt.parse_string(inp, ignore_errors=args.ignore_rst_errors)
 
     if args.verbose:
         print("=" * 60, fn, file=sys.stderr)
@@ -70,6 +70,9 @@ def main() -> None:
     )
     parser.add_argument(
         "-v", "--verbose", action="store_true", help="[internal] print extra debugging information"
+    )
+    parser.add_argument(
+        "--ignore-rst-errors", action="store_true", help="continue processing even if RST parsing encounters errors"
     )
     parser.add_argument("paths", nargs="*", help="files/directories to run on", metavar="path")
 

--- a/rstfmt/__main__.py
+++ b/rstfmt/__main__.py
@@ -15,7 +15,11 @@ STDIN = "-"
 def do_file(args, fn, misformatted):
     cm = cast(ContextManager[TextIO], nullcontext(sys.stdin) if fn == STDIN else open(fn))
     with cm as f:
-        inp = f.read()
+        try:
+            inp = f.read()
+        except Exception as e:
+            print(f"Error reading {fn}: {e}", file=sys.stderr)
+            return
     doc = rstfmt.parse_string(inp, ignore_errors=args.ignore_rst_errors)
 
     if args.verbose:

--- a/rstfmt/__main__.py
+++ b/rstfmt/__main__.py
@@ -82,6 +82,10 @@ def main() -> None:
     rst_extras.register()
 
     misformatted = []
+    
+    # if no paths are given and no stdin then use current directory to prevent hung state
+    if not args.paths and sys.stdin.isatty():
+        args.paths = [os.getcwd()]
 
     for path in args.paths or [STDIN]:
         if os.path.isdir(path):

--- a/rstfmt/rstfmt.py
+++ b/rstfmt/rstfmt.py
@@ -278,7 +278,20 @@ class IgnoreMessagesReporter(docutils.utils.Reporter):
         orig_level = self.halt_level  # type: ignore
         if message in self.ignored_messages:
             self.halt_level = docutils.utils.Reporter.SEVERE_LEVEL + 1
-        msg = super().system_message(level, message, *children, **kwargs)
+        try:
+            msg = super().system_message(level, message, *children, **kwargs)
+        except Exception as e:
+            print(f"Error in system_message: {e}")
+            self.halt_level = docutils.utils.Reporter.SEVERE_LEVEL + 1
+            # Create a basic system message since the original one failed
+            msg = docutils.nodes.system_message(
+                message=f"Error processing message: {e}",
+                level=level,
+                type=self.levels[level],
+                source=kwargs.get('source'),
+                line=kwargs.get('line')
+            )
+            
         self.halt_level = orig_level
         return msg
 
@@ -726,6 +739,11 @@ class Formatters:
         assert first.startswith(".. ")
         yield f".. |{name}| " + first[3:]
         yield from lines
+
+    @staticmethod
+    def problematic(node: docutils.nodes.problematic, ctx: FormatContext) -> inline_iterator:
+        """Handle problematic nodes by simply returning their content."""
+        yield from chain(fmt_children(node, ctx))
 
 
 def fmt(node: docutils.nodes.Node, ctx: FormatContext) -> Iterator[str]:

--- a/rstfmt/rstfmt.py
+++ b/rstfmt/rstfmt.py
@@ -272,6 +272,10 @@ class IgnoreMessagesReporter(docutils.utils.Reporter):
         "Title underline too short.",
     }
 
+    def __init__(self, source, report_level, halt_level, debug=False, error_handler="backslashreplace", ignore_errors=False):
+        super().__init__(source, report_level, halt_level, debug, error_handler)
+        self.ignore_errors = ignore_errors
+
     def system_message(
         self, level: int, message: str, *children: Any, **kwargs: Any
     ) -> docutils.nodes.system_message:
@@ -281,6 +285,11 @@ class IgnoreMessagesReporter(docutils.utils.Reporter):
         try:
             msg = super().system_message(level, message, *children, **kwargs)
         except Exception as e:
+            if not self.ignore_errors:
+                # If we're not ignoring errors, re-raise
+                self.halt_level = orig_level
+                raise
+            
             print(f"Error in system_message: {e}")
             self.halt_level = docutils.utils.Reporter.SEVERE_LEVEL + 1
             # Create a basic system message since the original one failed
@@ -763,7 +772,7 @@ def format_node(width: Optional[int], node: docutils.nodes.Node) -> str:
     return ret
 
 
-def parse_string(s: str) -> docutils.nodes.document:
+def parse_string(s: str, ignore_errors: bool = False) -> docutils.nodes.document:
     parser = docutils.parsers.rst.Parser()
     settings = docutils.frontend.OptionParser(
         components=[docutils.parsers.rst.Parser]
@@ -772,7 +781,12 @@ def parse_string(s: str) -> docutils.nodes.document:
     settings.halt_level = docutils.utils.Reporter.WARNING_LEVEL
     settings.file_insertion_enabled = False
     doc = docutils.utils.new_document("", settings=settings)
-    doc.reporter = IgnoreMessagesReporter("", settings.report_level, settings.halt_level)
+    doc.reporter = IgnoreMessagesReporter(
+        "", 
+        settings.report_level, 
+        settings.halt_level, 
+        ignore_errors=ignore_errors
+    )
     parser.parse(s, doc)
     preproc(doc)
 


### PR DESCRIPTION
This "addresses" many of the issues where users reported failures due to rst formatting errors by adding an option to ignore these errors.

https://github.com/dzhu/rstfmt/issues/39
https://github.com/dzhu/rstfmt/issues/34
https://github.com/dzhu/rstfmt/issues/33
https://github.com/dzhu/rstfmt/issues/32
https://github.com/dzhu/rstfmt/issues/30